### PR TITLE
Optimise `__iter__`

### DIFF
--- a/simd.py
+++ b/simd.py
@@ -163,10 +163,11 @@ class A:
 
     def __iter__(self) -> t.Iterator[int]:
         nbits = self.s.bi * self.s.len
-        bits = bin(self.data)[2:].zfill(nbits)[::-1]
+        bits = f"{self.data:0{nbits}b}"
         for i in range(self.s.len):
-            x = bits[i * self.s.bi : (i + 1) * self.s.bi]
-            yield int(x[: self.s.bv][::-1], 2)
+            # note: we can't use negative indexing for the range end, because it would fail when i==0
+            x = bits[-(i + 1) * self.s.bi + self.s.bp: len(bits) - i * self.s.bi]
+            yield int(x, 2)
 
     def __str__(self, /) -> str:
         res = []

--- a/simd.py
+++ b/simd.py
@@ -166,7 +166,7 @@ class A:
         bits = f"{self.data:0{nbits}b}"
         for i in range(self.s.len):
             # note: we can't use negative indexing for the range end, because it would fail when i==0
-            x = bits[-(i + 1) * self.s.bi + self.s.bp: len(bits) - i * self.s.bi]
+            x = bits[-(i + 1) * self.s.bi + self.s.bp : len(bits) - i * self.s.bi]
             yield int(x, 2)
 
     def __str__(self, /) -> str:

--- a/test_simd.py
+++ b/test_simd.py
@@ -216,4 +216,7 @@ def test_iter() -> None:
     a = A(0x_05_04_03_02_01, s)
     assert list(a) == [1, 2, 3, 4, 5] # note the "reversed" order
 
+    a = A(0x_056_034_012, simd.S(len=3, bv=8, bp=4))
+    assert list(a) == [0x12, 0x34, 0x56]
+
 # fmt: on


### PR DESCRIPTION
This uses an fstring to do the padded bit conversion, which I *think* is faster because it's a single operation (untested), but the more important change is that it avoids the need to reverse and then un-reverse the bits.

There could be further special-case optimisations involving to_bytes/from_bytes when the lane sizes are multiples of 8 bits.